### PR TITLE
Frames規格マスタデータの作成

### DIFF
--- a/app/models/frame.rb
+++ b/app/models/frame.rb
@@ -1,0 +1,8 @@
+class Frame < ApplicationRecord
+    enum direction: { vertical: 0, horizontal: 1 }
+
+    validates :name, presence: true
+    validates :short_side, presence: true, numericality: { only_integer: true, greater_than: 0 }
+    validates :long_side, presence: true, numericality: { only_integer: true, greater_than: 0 }
+    validates :direction, presence: true
+end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,1 +1,1 @@
-<h1>hello</div>
+<h1>hello!</div>

--- a/db/migrate/20260224141202_create_frames.rb
+++ b/db/migrate/20260224141202_create_frames.rb
@@ -1,0 +1,13 @@
+class CreateFrames < ActiveRecord::Migration[7.2]
+  def change
+    create_table :frames do |t|
+      t.string :name, null: false
+      t.integer :short_side, null: false
+      t.integer :long_side, null: false
+      t.integer :direction, default: 0, null: false
+
+      t.timestamps
+    end
+    add_index :frames, [ :name, :direction ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,2 +1,26 @@
-ActiveRecord::Schema[7.2].define(version: 0) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2026_02_24_141202) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "frames", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "short_side", null: false
+    t.integer "long_side", null: false
+    t.integer "direction", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "direction"], name: "index_frames_on_name_and_direction", unique: true
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,35 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+Frame.destroy_all
+
+puts "-------フレームデータを作成します--------"
+
+Frame.create!(name: 'A4', short_side: 210, long_side: 297, direction: :vertical)
+Frame.create!(name: 'A3', short_side: 297, long_side: 420, direction: :vertical)
+Frame.create!(name: 'A2', short_side: 420, long_side: 594, direction: :vertical)
+Frame.create!(name: 'A1', short_side: 594, long_side: 841, direction: :vertical)
+
+# B判サイズ（縦向き）
+Frame.create!(name: 'B3', short_side: 364, long_side: 515, direction: :vertical)
+Frame.create!(name: 'B2', short_side: 515, long_side: 728, direction: :vertical)
+Frame.create!(name: 'B1', short_side: 728, long_side: 1030, direction: :vertical)
+
+# 写真サイズ
+Frame.create!(name: 'L判', short_side: 89, long_side: 127, direction: :vertical)
+Frame.create!(name: '2L判', short_side: 127, long_side: 178, direction: :vertical)
+Frame.create!(name: '六切', short_side: 203, long_side: 254, direction: :vertical)
+Frame.create!(name: '四切', short_side: 254, long_side: 305, direction: :vertical)
+Frame.create!(name: 'ワイド四切', short_side: 254, long_side: 366, direction: :vertical)
+
+# 油絵サイズ（P号）
+Frame.create!(name: 'P10', short_side: 410, long_side: 530, direction: :vertical)
+Frame.create!(name: 'P20', short_side: 530, long_side: 727, direction: :vertical)
+Frame.create!(name: 'P30', short_side: 652, long_side: 910, direction: :vertical)
+
+# 油絵サイズ（F号）
+Frame.create!(name: 'F10', short_side: 455, long_side: 530, direction: :vertical)
+Frame.create!(name: 'F20', short_side: 606, long_side: 727, direction: :vertical)
+Frame.create!(name: 'F30', short_side: 727, long_side: 910, direction: :vertical)
+
+puts "-------#{Frame.count}件のフレームデータを作成しました--------"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,35 +7,70 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
-Frame.destroy_all
+if Frame.count > 0
+  puts "-----フレームは既に存在します。シードをスキップします。-----"
+  exit
+end
 
 puts "-------フレームデータを作成します--------"
 
+# A判
 Frame.create!(name: 'A4', short_side: 210, long_side: 297, direction: :vertical)
+Frame.create!(name: 'A4', short_side: 210, long_side: 297, direction: :horizontal)
+
 Frame.create!(name: 'A3', short_side: 297, long_side: 420, direction: :vertical)
+Frame.create!(name: 'A3', short_side: 297, long_side: 420, direction: :horizontal)
+
 Frame.create!(name: 'A2', short_side: 420, long_side: 594, direction: :vertical)
+Frame.create!(name: 'A2', short_side: 420, long_side: 594, direction: :horizontal)
+
 Frame.create!(name: 'A1', short_side: 594, long_side: 841, direction: :vertical)
+Frame.create!(name: 'A1', short_side: 594, long_side: 841, direction: :horizontal)
 
-# B判サイズ（縦向き）
+# B判
 Frame.create!(name: 'B3', short_side: 364, long_side: 515, direction: :vertical)
+Frame.create!(name: 'B3', short_side: 364, long_side: 515, direction: :horizontal)
+
 Frame.create!(name: 'B2', short_side: 515, long_side: 728, direction: :vertical)
+Frame.create!(name: 'B2', short_side: 515, long_side: 728, direction: :horizontal)
+
 Frame.create!(name: 'B1', short_side: 728, long_side: 1030, direction: :vertical)
+Frame.create!(name: 'B1', short_side: 728, long_side: 1030, direction: :horizontal)
 
-# 写真サイズ
+# 写真判
 Frame.create!(name: 'L判', short_side: 89, long_side: 127, direction: :vertical)
-Frame.create!(name: '2L判', short_side: 127, long_side: 178, direction: :vertical)
-Frame.create!(name: '六切', short_side: 203, long_side: 254, direction: :vertical)
-Frame.create!(name: '四切', short_side: 254, long_side: 305, direction: :vertical)
-Frame.create!(name: 'ワイド四切', short_side: 254, long_side: 366, direction: :vertical)
+Frame.create!(name: 'L判', short_side: 89, long_side: 127, direction: :horizontal)
 
-# 油絵サイズ（P号）
+Frame.create!(name: '2L判', short_side: 127, long_side: 178, direction: :vertical)
+Frame.create!(name: '2L判', short_side: 127, long_side: 178, direction: :horizontal)
+
+Frame.create!(name: '六切', short_side: 203, long_side: 254, direction: :vertical)
+Frame.create!(name: '六切', short_side: 203, long_side: 254, direction: :horizontal)
+
+Frame.create!(name: '四切', short_side: 254, long_side: 305, direction: :vertical)
+Frame.create!(name: '四切', short_side: 254, long_side: 305, direction: :horizontal)
+
+Frame.create!(name: 'ワイド四切', short_side: 254, long_side: 366, direction: :vertical)
+Frame.create!(name: 'ワイド四切', short_side: 254, long_side: 366, direction: :horizontal)
+
+# 油彩判
 Frame.create!(name: 'P10', short_side: 410, long_side: 530, direction: :vertical)
+Frame.create!(name: 'P10', short_side: 410, long_side: 530, direction: :horizontal)
+
 Frame.create!(name: 'P20', short_side: 530, long_side: 727, direction: :vertical)
+Frame.create!(name: 'P20', short_side: 530, long_side: 727, direction: :horizontal)
+
 Frame.create!(name: 'P30', short_side: 652, long_side: 910, direction: :vertical)
+Frame.create!(name: 'P30', short_side: 652, long_side: 910, direction: :horizontal)
 
 # 油絵サイズ（F号）
 Frame.create!(name: 'F10', short_side: 455, long_side: 530, direction: :vertical)
+Frame.create!(name: 'F10', short_side: 455, long_side: 530, direction: :horizontal)
+
 Frame.create!(name: 'F20', short_side: 606, long_side: 727, direction: :vertical)
+Frame.create!(name: 'F20', short_side: 606, long_side: 727, direction: :horizontal)
+
 Frame.create!(name: 'F30', short_side: 727, long_side: 910, direction: :vertical)
+Frame.create!(name: 'F30', short_side: 727, long_side: 910, direction: :horizontal)
 
 puts "-------#{Frame.count}件のフレームデータを作成しました--------"

--- a/test/fixtures/frames.yml
+++ b/test/fixtures/frames.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/frame_test.rb
+++ b/test/models/frame_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FrameTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
開発環境:Rails postgreSQL
本番環境:Neon

 **Framesテーブル作成/ マイグレーションファイル作成**

- [ ] マスタデータの整合性を保つため各カラムにはnull制約を設けました。

**model/frame.rb作成/seeds.rbにて用紙規格サイズのマスタデータを作成**

- [ ] フレームの向きが縦横どちらが選択されても対応できるように設計しました。

　　　name: 'A4', short_side: 210, long_side: 297, direction: :vertical　縦
　　　name: 'A4', short_side: 210, long_side: 297, direction: :horizontal　横

     

- [ ]  データ重複防止・seedfileの冪等性を保つために以下を記載

　　　if Frame.count > 0
  　　　puts "Frames already exist. Skipping seed."
 　　　 exit
　　　end
　　補足：Frame.destroy_all を使うと本番環境にデータが登録されたら、Start Command を元の状態に戻すのが面倒。→データが既に存在する場合はスキップするように実装。

この方法なら何度デプロイしても seed が実行されても安全
* 初回デプロイ時: データがないので seed が実行される
* 2回目以降: データが既に存在するのでスキップされる
*  Start Command を変更する必要がない



# seedファイルを修正して再実行する手順
現在のデータを削除する
 rails c

既存の額縁データを全削除
  Frame.destroy_all

 削除されたことを確認
   Frame.count
    => 0
   コンソールを終了
      exit

seeds編集後以下コマンド
　docker compose exec web rails db:seed


# データ確認
docker compose exec web rails c

全データ確認
Frame.all

件数確認
Frame.count

特定のデータ確認
Frame.find_by(name: 'A4')

縦向きのデータのみ
Frame.vertical

横向きのデータのみ
Frame.horizontal


 