### PR TITLE
Add:診断ロジック修正

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -70,6 +70,8 @@
   .item {
     display: flex;
     justify-content: space-between;
+    list-style: none;
+    padding: 0;
 
     li {
       flex: 1;

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -23,7 +23,6 @@ if @diagnosis_form.valid?
 
   redirect_to result_diagnoses_path
 else
-  # バリデーション失敗時は render を使う
   render :new, status: :unprocessable_entity
 end
 end

--- a/app/forms/diagnosis_form.rb
+++ b/app/forms/diagnosis_form.rb
@@ -6,6 +6,35 @@ class DiagnosisForm
   attribute :location_type, :string
   attribute :direction, :string
 
-  validates :base_width, presence: true, numericality: { only_integer: true, greater_than: 0 }
-  validates :location_type, presence: true
+  validates :base_width, presence: true
+  validate :validate_base_width_by_conditions
+
+  # verticalの最小幅
+  VERTICAL_MIN_WIDTHS = {
+    "wall" => 199,
+    "furniture" => 144
+  }
+
+  # horizontalの最小幅
+  HORIZONTAL_MIN_WIDTHS = {
+    "wall" => 284,
+    "furniture" => 205
+  }
+
+  private
+
+  def validate_base_width_by_conditions
+    return if base_width.blank? || location_type.blank?
+
+    min_width = minimum_width_for_current_condition
+    return unless min_width
+    return if base_width >= min_width
+
+    errors.add(:base_width, "は#{min_width}mm以上の値を入力してください")
+  end
+
+  def minimum_width_for_current_condition
+    widths = direction == "horizontal" ? HORIZONTAL_MIN_WIDTHS : VERTICAL_MIN_WIDTHS
+    widths[location_type]
+  end
 end

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -6,7 +6,7 @@
 
     <div class="mb-3">
       <%= f.label :base_width, "設置場所の幅（mm）" %>
-      <%= f.number_field :base_width, placeholder: "例: 1200" %>
+      <%= f.number_field :base_width, placeholder: "例: 1200 (半角)" %>
     </div>
 
     <div class="mb-3">

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -7,11 +7,3 @@ ja:
         base_width: 壁・家具の幅
         location_type: 飾る場所
         direction: 額縁の向き
-    errors:
-      models:
-        diagnosis_form:
-          attributes:
-            base_width:
-              blank: を入力してください
-              not_a_number: は数値で入力してください
-              greater_than: は0より大きい値を入力してください


### PR DESCRIPTION
最小フレームサイズであるL判を基準にし、横幅の最小幅を各選択肢によって分岐させるため、Form objectにロジックを追加しました。

L判:  short_side: 89, long_side: 127

縦向きで飾る場合:VERTICAL_MIN_WIDTHS
・ 壁に飾る場合
  理想の壁幅：約 199mm
・家具の上に飾る場合
　理想の家具幅：約 144mm

横向きで飾る場合:HORIZONTAL_MIN_WIDTHS
• 壁に飾る場合
  理想の壁幅：約 284mm
• 家具の上に飾る場合
  理想の家具幅：約 205mm
